### PR TITLE
feat: pull tasklist environment configuration from .env file in specs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18682,6 +18682,7 @@
         "camunda-8-credentials-from-env": "^1.1.1",
         "camunda-saas-oauth": "^1.2.4",
         "debug": "^4.3.4",
+        "dotenv": "^16.3.1",
         "gotql": "^2.1.0-alpha1"
       },
       "devDependencies": {

--- a/packages/tasklist-client-node-js/.env.example
+++ b/packages/tasklist-client-node-js/.env.example
@@ -1,0 +1,14 @@
+# This is an example .env file, listing the keys required to run tests locally.
+#  Duplicate this file as `.env` instead of `.env.example`, and populate the keys from a valid cluster API client.
+#  See the docs on how to create a cluster API client and obtain these keys: 
+#    https://docs.camunda.io/docs/components/console/manage-clusters/manage-api-clients/#create-a-client
+export ZEEBE_ADDRESS=
+export ZEEBE_CLIENT_ID=
+export ZEEBE_CLIENT_SECRET=
+export ZEEBE_AUTHORIZATION_SERVER_URL=
+export ZEEBE_TOKEN_AUDIENCE=
+export CAMUNDA_CLUSTER_ID=
+export CAMUNDA_CLUSTER_REGION=
+export CAMUNDA_CREDENTIALS_SCOPES=
+export CAMUNDA_TASKLIST_BASE_URL=
+export CAMUNDA_OAUTH_URL=

--- a/packages/tasklist-client-node-js/DEVELOP.md
+++ b/packages/tasklist-client-node-js/DEVELOP.md
@@ -1,0 +1,7 @@
+# Development
+
+## Testing
+
+Tests for this client require environment variables to be configured based on a valid cluster API client. [See these docs](https://docs.camunda.io/docs/components/console/manage-clusters/manage-api-clients/#create-a-client) for more information about creating a cluster API client, and obtaining the necessary environment variables.
+
+The environment variables can be defined manually in the terminal instance prior to running the tests, or you may create a `.env` file to hold them. See [.env.example](./.env.example) for an example configuration containing the necessary keys.

--- a/packages/tasklist-client-node-js/package.json
+++ b/packages/tasklist-client-node-js/package.json
@@ -37,6 +37,7 @@
     "camunda-8-credentials-from-env": "^1.1.1",
     "camunda-saas-oauth": "^1.2.4",
     "debug": "^4.3.4",
+    "dotenv": "^16.3.1",
     "gotql": "^2.1.0-alpha1"
   }
 }

--- a/packages/tasklist-client-node-js/src/__test__/restclient.spec.ts
+++ b/packages/tasklist-client-node-js/src/__test__/restclient.spec.ts
@@ -2,6 +2,7 @@ import { TaskState } from "../lib/Types"
 import {TasklistRESTClient} from "./../index"
 import { join } from 'path'
 import { CreateProcessInstanceResponse, DeployProcessResponse, ZBClient } from 'zeebe-node'
+import 'dotenv/config'
 
 jest.setTimeout(25000) // increase timeout to allow Tasklist application to create tasks
 

--- a/packages/tasklist-client-node-js/src/__test__/test.spec.ts
+++ b/packages/tasklist-client-node-js/src/__test__/test.spec.ts
@@ -2,6 +2,7 @@ import { TaskState } from "../lib/Types"
 import {TasklistApiClient} from "./../index"
 import { join } from 'path'
 import { CreateProcessInstanceResponse, DeployProcessResponse, ZBClient } from 'zeebe-node'
+import 'dotenv/config'
 
 jest.setTimeout(25000) // increase timeout to allow Tasklist application to create tasks
 


### PR DESCRIPTION
Adds the `dotenv` dependency, and configures the Tasklist specs to import environment variables from a `.env` file. Also includes a `.env.example` file including all the necessary keys, and docs on how to set up a valid `.env` file.

I only applied this to the Tasklist client, but maybe it's something we want to apply to all of them.