### PR TITLE
feat: get Tasklist REST API and specs working/passing

### DIFF
--- a/packages/tasklist-client-node-js/src/__test__/restclient.spec.ts
+++ b/packages/tasklist-client-node-js/src/__test__/restclient.spec.ts
@@ -141,33 +141,8 @@ describe('TasklistRESTClient', () => {
             expect(tasks.length).toBeGreaterThan(0)
             const completeTask = await tasklist.completeTask(taskid, { outcome: 'approved', fruits: ['apple', 'orange'] })
             expect(completeTask.id).toBe(taskid)
+            expect(completeTask.taskState).toEqual(TaskStateREST.COMPLETED)
             p = null as any
-        })
-
-        it('can complete a task with variables', (done) => {
-            const tasklist = new TasklistRESTClient()
-            zbc.createProcessInstanceWithResult({
-                bpmnProcessId: 'TasklistTestProcess',
-                variables: {
-                    name: 'Joe Bloggs',
-                    age: 42,
-                    interests: ['golf', 'frisbee'],
-                },
-            }).then((res) => {
-                console.log(res)
-                p = null as any
-                done()
-            })
-            delay(10000)
-                .then(() => tasklist.getTasks({ state: TaskStateREST.CREATED }))
-                .then((tasks) =>
-                    tasks.forEach((task) =>
-                        tasklist.completeTask(task.id, {
-                            outcome: 'approved',
-                            fruits: ['apple', 'orange'],
-                        })
-                    )
-                )
         })
     })
 })

--- a/packages/tasklist-client-node-js/src/__test__/restclient.spec.ts
+++ b/packages/tasklist-client-node-js/src/__test__/restclient.spec.ts
@@ -18,10 +18,7 @@ describe('TasklistRESTClient', () => {
 
     beforeEach(async () => {
         const bpmnFilePath = join(process.cwd(), 'src', '__test__', 'resources', 'TasklistTestProcess.bpmn')
-        console.log(`Deploying ${bpmnFilePath}...`)
         def = await zbc.deployProcess(bpmnFilePath)
-        console.log('def', def)
-        console.log(`Deployed ${def.processes[0].bpmnProcessId}`)
 
         p = await zbc.createProcessInstance({
             bpmnProcessId: 'TasklistTestProcess',
@@ -31,8 +28,6 @@ describe('TasklistRESTClient', () => {
                 interests: ['golf', 'frisbee'],
             },
         })
-        console.log(`Created instance ${p.processInstanceKey}`)
-        console.log(`Waiting for 10s for Tasklist to do its thing`)
         await delay(10000) // we wait here to allow Tasklist to do its thing
     })
 
@@ -134,11 +129,8 @@ describe('TasklistRESTClient', () => {
                 threw = true
             }
             expect(threw).toBe(true)
-            console.log("can't assign twice")
             await tasklist.unassignTask(taskId)
-            console.log('unassigned')
             const claimTask = await tasklist.assignTask({ taskId, assignee: 'jwulf0', allowOverrideAssignment: false })
-            console.log('re-assigned')
             expect(claimTask.id).toEqual(taskId)
         })
 
@@ -152,7 +144,7 @@ describe('TasklistRESTClient', () => {
             p = null as any
         })
 
-        xit('can complete a task with variables', (done) => {
+        it('can complete a task with variables', (done) => {
             const tasklist = new TasklistRESTClient()
             zbc.createProcessInstanceWithResult({
                 bpmnProcessId: 'TasklistTestProcess',

--- a/packages/tasklist-client-node-js/src/__test__/restclient.spec.ts
+++ b/packages/tasklist-client-node-js/src/__test__/restclient.spec.ts
@@ -10,15 +10,17 @@ let p: CreateProcessInstanceResponse
 let def: DeployProcessResponse
 
 const delay = (ms: number) => new Promise((resolve) => setTimeout(() => resolve(null), ms))
+
 describe('TasklistRESTClient', () => {
     const zbc = new ZBClient({
         loglevel: 'NONE',
     })
 
-    beforeAll(async () => {
+    beforeEach(async () => {
         const bpmnFilePath = join(process.cwd(), 'src', '__test__', 'resources', 'TasklistTestProcess.bpmn')
         console.log(`Deploying ${bpmnFilePath}...`)
         def = await zbc.deployProcess(bpmnFilePath)
+        console.log('def', def)
         console.log(`Deployed ${def.processes[0].bpmnProcessId}`)
 
         p = await zbc.createProcessInstance({
@@ -34,137 +36,146 @@ describe('TasklistRESTClient', () => {
         await delay(10000) // we wait here to allow Tasklist to do its thing
     })
 
-    afterAll(async () => {
+    afterEach(async () => {
         if (p && p.processInstanceKey) {
             await zbc.cancelProcessInstance(p.processInstanceKey)
         }
+    })
+
+    afterAll(() => {
         zbc.close()
     })
 
-    it('can request all tasks', async () => {
-        const tasklist = new TasklistRESTClient()
-        const tasks = await tasklist.getAllTasks()
-        console.log('tasks', tasks)
-        expect(tasks.length).toBeGreaterThan(0)
-    })
-
-    it('can request a task with parameters', async () => {
-        const tasklist = new TasklistRESTClient()
-        const tasks = await tasklist.getTasks({
-            state: TaskStateREST.CREATED,
+    describe('Read operations', () => {
+        it('can request all tasks', async () => {
+            const tasklist = new TasklistRESTClient()
+            const tasks = await tasklist.getAllTasks()
+            expect(tasks.length).toBeGreaterThan(0)
         })
-        expect(tasks.length).toBeGreaterThan(0)
-    })
 
-    it('gets all fields for a task', async () => {
-        const tasklist = new TasklistRESTClient()
-        const tasks = await tasklist.getTasks({
-            state: TaskStateREST.CREATED,
+        it('can request a task with parameters', async () => {
+            const tasklist = new TasklistRESTClient()
+            const tasks = await tasklist.getTasks({
+                state: TaskStateREST.CREATED,
+            })
+            expect(tasks.length).toBeGreaterThan(0)
         })
-        expect(tasks.length).toBeGreaterThan(0)
-        expect(tasks[0].name).toBeTruthy()
-        expect(tasks[0].processName).toBeTruthy()
-    })
 
-    it('can request tasks with all fields', async () => {
-        const tasklist = new TasklistRESTClient()
-        const tasks = await tasklist.getTasks({
-            state: TaskStateREST.CREATED,
+        it('gets all fields for a task', async () => {
+            const tasklist = new TasklistRESTClient()
+            const tasks = await tasklist.getTasks({
+                state: TaskStateREST.CREATED,
+            })
+            expect(tasks.length).toBeGreaterThan(0)
+            expect(tasks[0].name).toBeTruthy()
+            expect(tasks[0].processName).toBeTruthy()
         })
-        expect(tasks.length).toBeGreaterThan(0)
-        expect(tasks[0].processName).toBeTruthy()
-    })
 
-    it('can request a specific task', async () => {
-        const tasklist = new TasklistRESTClient()
-        const tasks = await tasklist.getTasks({
-            state: TaskStateREST.CREATED,
+        it('can request tasks with all fields', async () => {
+            const tasklist = new TasklistRESTClient()
+            const tasks = await tasklist.getTasks({
+                state: TaskStateREST.CREATED,
+            })
+            expect(tasks.length).toBeGreaterThan(0)
+            expect(tasks[0].processName).toBeTruthy()
         })
-        const id = tasks[0].id
-        const task = await tasklist.getTask(id)
-        expect(task.id).toBe(id)
+
+        it('can request a specific task', async () => {
+            const tasklist = new TasklistRESTClient()
+            const tasks = await tasklist.getTasks({
+                state: TaskStateREST.CREATED,
+            })
+            const id = tasks[0].id
+            const task = await tasklist.getTask(id)
+            expect(task.id).toBe(id)
+        })
+
+        it('can retrieve an embedded form', async () => {
+            const tasklist = new TasklistRESTClient()
+            const res = await tasklist.getForm('userTaskForm_3r97fja', def.processes[0].processDefinitionKey)
+            expect(res.id).toBe('userTaskForm_3r97fja')
+        })
+
+        it('can claim a task', async () => {
+            const tasklist = new TasklistRESTClient()
+            const tasks = await tasklist.getTasks({ state: TaskStateREST.CREATED })
+            const taskid = tasks[0].id
+            expect(tasks.length).toBeGreaterThan(0)
+            const claimTask = await tasklist.assignTask({ taskId: taskid, assignee: 'jwulf' })
+            expect(claimTask.id).toBe(taskid)
+        })
     })
 
-    it.only('can retrieve an embedded form', async () => {
-        const tasklist = new TasklistRESTClient()
-        const res = await tasklist.getForm('userTaskForm_3r97fja', def.processes[0].processDefinitionKey)
-        expect(res.id).toBe('userTaskForm_3r97fja')
-    })
+    describe('Write operations', () => {
+        it('will not allow a task to be claimed twice', async () => {
+            const tasklist = new TasklistRESTClient()
+            const tasks = await tasklist.getTasks({ state: TaskStateREST.CREATED })
+            const task = await tasklist.assignTask({ taskId: tasks[0].id, assignee: 'jwulf' })
+            expect(task).toBeTruthy()
+            let threw = false
+            try {
+                await tasklist.assignTask({ taskId: tasks[0].id, assignee: 'jwulf0', allowOverrideAssignment: false })
+            } catch (e) {
+                threw = true
+            }
+            expect(threw).toBe(true)
+        })
 
-    it('can claim a task', async () => {
-        const tasklist = new TasklistRESTClient()
-        const tasks = await tasklist.getTasks({ state: TaskStateREST.CREATED })
-        const taskid = tasks[0].id
-        expect(tasks.length).toBeGreaterThan(0)
-        const claimTask = await tasklist.assignTask({ taskId: taskid, assignee: 'jwulf' })
-        expect(claimTask.id).toBe(taskid)
-    })
+        it('can unclaim task', async () => {
+            const tasklist = new TasklistRESTClient()
+            const tasks = await tasklist.getTasks({ state: TaskStateREST.CREATED })
+            const taskId = tasks[0].id
+            const task = await tasklist.assignTask({ taskId: taskId, assignee: 'jwulf', allowOverrideAssignment: false })
+            expect(task).toBeTruthy()
+            let threw = false
+            try {
+                await tasklist.assignTask({ taskId: taskId, assignee: 'jwulf0', allowOverrideAssignment: false })
+            } catch {
+                threw = true
+            }
+            expect(threw).toBe(true)
+            console.log("can't assign twice")
+            await tasklist.unassignTask(taskId)
+            console.log('unassigned')
+            const claimTask = await tasklist.assignTask({ taskId, assignee: 'jwulf0', allowOverrideAssignment: false })
+            console.log('re-assigned')
+            expect(claimTask.id).toEqual(taskId)
+        })
 
-    it('will not allow a task to be claimed twice', async () => {
-        const tasklist = new TasklistRESTClient()
-        const tasks = await tasklist.getTasks({ state: TaskStateREST.CREATED })
-        const task = await tasklist.assignTask({ taskId: tasks[0].id, assignee: 'jwulf' })
-        expect(task).toBeTruthy()
-        let threw = false
-        try {
-            await tasklist.assignTask({ taskId: tasks[0].id, assignee: 'jwulf0', allowOverrideAssignment: false })
-        } catch (e) {
-            threw = true
-        }
-        expect(threw).toBe(true)
-    })
-
-    it('can unclaim task', async () => {
-        const tasklist = new TasklistRESTClient()
-        const tasks = await tasklist.getTasks({ state: TaskStateREST.CREATED })
-        const taskId = tasks[0].id
-        const task = await tasklist.assignTask({ taskId: taskId, assignee: 'jwulf' })
-        expect(task).toBeTruthy()
-        let threw = false
-        try {
-            await tasklist.assignTask({ taskId: taskId, assignee: 'jwulf0', allowOverrideAssignment: false })
-        } catch {
-            threw = true
-        }
-        expect(threw).toBe(true)
-        await tasklist.unassignTask(taskId)
-        const claimTask = await tasklist.assignTask({ taskId, assignee: 'jwulf0', allowOverrideAssignment: false })
-        expect(claimTask.id).toEqual(taskId)
-    })
-
-    it('can complete a Task', async () => {
-        const tasklist = new TasklistRESTClient()
-        const tasks = await tasklist.getTasks({ state: TaskStateREST.CREATED })
-        const taskid = tasks[0].id
-        expect(tasks.length).toBeGreaterThan(0)
-        const completeTask = await tasklist.completeTask(taskid, { outcome: 'approved', fruits: ['apple', 'orange'] })
-        expect(completeTask.id).toBe(taskid)
-        p = null as any
-    })
-
-    it('can complete a task with variables', (done) => {
-        const tasklist = new TasklistRESTClient()
-        zbc.createProcessInstanceWithResult({
-            bpmnProcessId: 'TasklistTestProcess',
-            variables: {
-                name: 'Joe Bloggs',
-                age: 42,
-                interests: ['golf', 'frisbee'],
-            },
-        }).then((res) => {
-            console.log(res)
+        it('can complete a Task', async () => {
+            const tasklist = new TasklistRESTClient()
+            const tasks = await tasklist.getTasks({ state: TaskStateREST.CREATED })
+            const taskid = tasks[0].id
+            expect(tasks.length).toBeGreaterThan(0)
+            const completeTask = await tasklist.completeTask(taskid, { outcome: 'approved', fruits: ['apple', 'orange'] })
+            expect(completeTask.id).toBe(taskid)
             p = null as any
-            done()
         })
-        delay(10000)
-            .then(() => tasklist.getTasks({ state: TaskStateREST.CREATED }))
-            .then((tasks) =>
-                tasks.forEach((task) =>
-                    tasklist.completeTask(task.id, {
-                        outcome: 'approved',
-                        fruits: ['apple', 'orange'],
-                    })
+
+        xit('can complete a task with variables', (done) => {
+            const tasklist = new TasklistRESTClient()
+            zbc.createProcessInstanceWithResult({
+                bpmnProcessId: 'TasklistTestProcess',
+                variables: {
+                    name: 'Joe Bloggs',
+                    age: 42,
+                    interests: ['golf', 'frisbee'],
+                },
+            }).then((res) => {
+                console.log(res)
+                p = null as any
+                done()
+            })
+            delay(10000)
+                .then(() => tasklist.getTasks({ state: TaskStateREST.CREATED }))
+                .then((tasks) =>
+                    tasks.forEach((task) =>
+                        tasklist.completeTask(task.id, {
+                            outcome: 'approved',
+                            fruits: ['apple', 'orange'],
+                        })
+                    )
                 )
-            )
+        })
     })
 })

--- a/packages/tasklist-client-node-js/src/__test__/restclient.spec.ts
+++ b/packages/tasklist-client-node-js/src/__test__/restclient.spec.ts
@@ -1,4 +1,3 @@
-import { TaskStateREST } from '../lib/Types'
 import { TasklistRESTClient } from './../index'
 import { join } from 'path'
 import { CreateProcessInstanceResponse, DeployProcessResponse, ZBClient } from 'zeebe-node'
@@ -51,7 +50,7 @@ describe('TasklistRESTClient', () => {
         it('can request a task with parameters', async () => {
             const tasklist = new TasklistRESTClient()
             const tasks = await tasklist.getTasks({
-                state: TaskStateREST.CREATED,
+                state: 'CREATED',
             })
             expect(tasks.length).toBeGreaterThan(0)
         })
@@ -59,7 +58,7 @@ describe('TasklistRESTClient', () => {
         it('gets all fields for a task', async () => {
             const tasklist = new TasklistRESTClient()
             const tasks = await tasklist.getTasks({
-                state: TaskStateREST.CREATED,
+                state: 'CREATED',
             })
             expect(tasks.length).toBeGreaterThan(0)
             expect(tasks[0].name).toBeTruthy()
@@ -69,7 +68,7 @@ describe('TasklistRESTClient', () => {
         it('can request a specific task', async () => {
             const tasklist = new TasklistRESTClient()
             const tasks = await tasklist.getTasks({
-                state: TaskStateREST.CREATED,
+                state: 'CREATED',
             })
             const id = tasks[0].id
             const task = await tasklist.getTask(id)
@@ -86,7 +85,7 @@ describe('TasklistRESTClient', () => {
     describe('Write operations', () => {
         it('can claim a task', async () => {
             const tasklist = new TasklistRESTClient()
-            const tasks = await tasklist.getTasks({ state: TaskStateREST.CREATED })
+            const tasks = await tasklist.getTasks({ state: 'CREATED' })
             const taskid = tasks[0].id
             expect(tasks.length).toBeGreaterThan(0)
             const claimTask = await tasklist.assignTask({ taskId: taskid, assignee: 'jwulf' })
@@ -95,7 +94,7 @@ describe('TasklistRESTClient', () => {
 
         it('will not allow a task to be claimed twice', async () => {
             const tasklist = new TasklistRESTClient()
-            const tasks = await tasklist.getTasks({ state: TaskStateREST.CREATED })
+            const tasks = await tasklist.getTasks({ state: 'CREATED' })
             const task = await tasklist.assignTask({ taskId: tasks[0].id, assignee: 'jwulf' })
             expect(task).toBeTruthy()
             let threw = false
@@ -109,7 +108,7 @@ describe('TasklistRESTClient', () => {
 
         it('can unclaim task', async () => {
             const tasklist = new TasklistRESTClient()
-            const tasks = await tasklist.getTasks({ state: TaskStateREST.CREATED })
+            const tasks = await tasklist.getTasks({ state: 'CREATED' })
             const taskId = tasks[0].id
             const task = await tasklist.assignTask({ taskId: taskId, assignee: 'jwulf', allowOverrideAssignment: false })
             expect(task).toBeTruthy()
@@ -127,12 +126,12 @@ describe('TasklistRESTClient', () => {
 
         it('can complete a Task', async () => {
             const tasklist = new TasklistRESTClient()
-            const tasks = await tasklist.getTasks({ state: TaskStateREST.CREATED })
+            const tasks = await tasklist.getTasks({ state: 'CREATED' })
             const taskid = tasks[0].id
             expect(tasks.length).toBeGreaterThan(0)
             const completeTask = await tasklist.completeTask(taskid, { outcome: 'approved', fruits: ['apple', 'orange'] })
             expect(completeTask.id).toBe(taskid)
-            expect(completeTask.taskState).toEqual(TaskStateREST.COMPLETED)
+            expect(completeTask.taskState).toEqual('COMPLETED')
             p = null as any
         })
     })

--- a/packages/tasklist-client-node-js/src/__test__/restclient.spec.ts
+++ b/packages/tasklist-client-node-js/src/__test__/restclient.spec.ts
@@ -16,10 +16,12 @@ describe('TasklistRESTClient', () => {
         loglevel: 'NONE',
     })
 
-    beforeEach(async () => {
+    beforeAll(async () => {
         const bpmnFilePath = join(process.cwd(), 'src', '__test__', 'resources', 'TasklistTestProcess.bpmn')
         def = await zbc.deployProcess(bpmnFilePath)
+    })
 
+    beforeEach(async () => {
         p = await zbc.createProcessInstance({
             bpmnProcessId: 'TasklistTestProcess',
             variables: {

--- a/packages/tasklist-client-node-js/src/__test__/restclient.spec.ts
+++ b/packages/tasklist-client-node-js/src/__test__/restclient.spec.ts
@@ -37,9 +37,7 @@ describe('TasklistRESTClient', () => {
         }
     })
 
-    afterAll(() => {
-        zbc.close()
-    })
+    afterAll(() => zbc.close())
 
     describe('Read operations', () => {
         it('can request all tasks', async () => {

--- a/packages/tasklist-client-node-js/src/__test__/restclient.spec.ts
+++ b/packages/tasklist-client-node-js/src/__test__/restclient.spec.ts
@@ -85,10 +85,10 @@ describe('TasklistRESTClient', () => {
         expect(task.id).toBe(id)
     })
 
-    it('can retrieve an embedded form', async () => {
+    it.only('can retrieve an embedded form', async () => {
         const tasklist = new TasklistRESTClient()
         const res = await tasklist.getForm('userTaskForm_3r97fja', def.processes[0].processDefinitionKey)
-        expect(res.form.id).toBe('userTaskForm_3r97fja')
+        expect(res.id).toBe('userTaskForm_3r97fja')
     })
 
     it('can claim a task', async () => {

--- a/packages/tasklist-client-node-js/src/__test__/restclient.spec.ts
+++ b/packages/tasklist-client-node-js/src/__test__/restclient.spec.ts
@@ -20,9 +20,7 @@ describe('TasklistRESTClient', () => {
         console.log(`Deploying ${bpmnFilePath}...`)
         def = await zbc.deployProcess(bpmnFilePath)
         console.log(`Deployed ${def.processes[0].bpmnProcessId}`)
-    })
 
-    beforeEach(async () => {
         p = await zbc.createProcessInstance({
             bpmnProcessId: 'TasklistTestProcess',
             variables: {
@@ -36,13 +34,12 @@ describe('TasklistRESTClient', () => {
         await delay(10000) // we wait here to allow Tasklist to do its thing
     })
 
-    afterEach(async () => {
+    afterAll(async () => {
         if (p && p.processInstanceKey) {
             await zbc.cancelProcessInstance(p.processInstanceKey)
         }
+        zbc.close()
     })
-
-    afterAll(() => zbc.close())
 
     it('can request all tasks', async () => {
         const tasklist = new TasklistRESTClient()

--- a/packages/tasklist-client-node-js/src/__test__/restclient.spec.ts
+++ b/packages/tasklist-client-node-js/src/__test__/restclient.spec.ts
@@ -81,7 +81,9 @@ describe('TasklistRESTClient', () => {
             const res = await tasklist.getForm('userTaskForm_3r97fja', def.processes[0].processDefinitionKey)
             expect(res.id).toBe('userTaskForm_3r97fja')
         })
+    })
 
+    describe('Write operations', () => {
         it('can claim a task', async () => {
             const tasklist = new TasklistRESTClient()
             const tasks = await tasklist.getTasks({ state: TaskStateREST.CREATED })
@@ -90,9 +92,7 @@ describe('TasklistRESTClient', () => {
             const claimTask = await tasklist.assignTask({ taskId: taskid, assignee: 'jwulf' })
             expect(claimTask.id).toBe(taskid)
         })
-    })
 
-    describe('Write operations', () => {
         it('will not allow a task to be claimed twice', async () => {
             const tasklist = new TasklistRESTClient()
             const tasks = await tasklist.getTasks({ state: TaskStateREST.CREATED })

--- a/packages/tasklist-client-node-js/src/__test__/restclient.spec.ts
+++ b/packages/tasklist-client-node-js/src/__test__/restclient.spec.ts
@@ -56,13 +56,13 @@ describe('TasklistRESTClient', () => {
         expect(tasks.length).toBeGreaterThan(0)
     })
 
-    it('can request tasks with fields', async () => {
+    it('gets all fields for a task', async () => {
         const tasklist = new TasklistRESTClient()
         const tasks = await tasklist.getTasks({
             state: TaskStateREST.CREATED,
         })
         expect(tasks.length).toBeGreaterThan(0)
-        expect(tasks[0].name).not.toBeDefined()
+        expect(tasks[0].name).toBeTruthy()
         expect(tasks[0].processName).toBeTruthy()
     })
 

--- a/packages/tasklist-client-node-js/src/__test__/restclient.spec.ts
+++ b/packages/tasklist-client-node-js/src/__test__/restclient.spec.ts
@@ -66,15 +66,6 @@ describe('TasklistRESTClient', () => {
             expect(tasks[0].processName).toBeTruthy()
         })
 
-        it('can request tasks with all fields', async () => {
-            const tasklist = new TasklistRESTClient()
-            const tasks = await tasklist.getTasks({
-                state: TaskStateREST.CREATED,
-            })
-            expect(tasks.length).toBeGreaterThan(0)
-            expect(tasks[0].processName).toBeTruthy()
-        })
-
         it('can request a specific task', async () => {
             const tasklist = new TasklistRESTClient()
             const tasks = await tasklist.getTasks({

--- a/packages/tasklist-client-node-js/src/__test__/restclient.spec.ts
+++ b/packages/tasklist-client-node-js/src/__test__/restclient.spec.ts
@@ -1,4 +1,4 @@
-import { TaskState } from '../lib/Types'
+import { TaskStateREST } from '../lib/Types'
 import { TasklistRESTClient } from './../index'
 import { join } from 'path'
 import { CreateProcessInstanceResponse, DeployProcessResponse, ZBClient } from 'zeebe-node'
@@ -51,7 +51,7 @@ describe('TasklistRESTClient', () => {
     it('can request a task with parameters', async () => {
         const tasklist = new TasklistRESTClient()
         const tasks = await tasklist.getTasks({
-            state: TaskState.CREATED,
+            state: TaskStateREST.CREATED,
         })
         expect(tasks.length).toBeGreaterThan(0)
     })
@@ -59,7 +59,7 @@ describe('TasklistRESTClient', () => {
     it('can request tasks with fields', async () => {
         const tasklist = new TasklistRESTClient()
         const tasks = await tasklist.getTasks({
-            state: TaskState.CREATED,
+            state: TaskStateREST.CREATED,
         })
         expect(tasks.length).toBeGreaterThan(0)
         expect(tasks[0].name).not.toBeDefined()
@@ -69,7 +69,7 @@ describe('TasklistRESTClient', () => {
     it('can request tasks with all fields', async () => {
         const tasklist = new TasklistRESTClient()
         const tasks = await tasklist.getTasks({
-            state: TaskState.CREATED,
+            state: TaskStateREST.CREATED,
         })
         expect(tasks.length).toBeGreaterThan(0)
         expect(tasks[0].processName).toBeTruthy()
@@ -78,7 +78,7 @@ describe('TasklistRESTClient', () => {
     it('can request a specific task', async () => {
         const tasklist = new TasklistRESTClient()
         const tasks = await tasklist.getTasks({
-            state: TaskState.CREATED,
+            state: TaskStateREST.CREATED,
         })
         const id = tasks[0].id
         const task = await tasklist.getTask(id)
@@ -93,7 +93,7 @@ describe('TasklistRESTClient', () => {
 
     it('can claim a task', async () => {
         const tasklist = new TasklistRESTClient()
-        const tasks = await tasklist.getTasks({ state: TaskState.CREATED })
+        const tasks = await tasklist.getTasks({ state: TaskStateREST.CREATED })
         const taskid = tasks[0].id
         expect(tasks.length).toBeGreaterThan(0)
         const claimTask = await tasklist.assignTask({ taskId: taskid, assignee: 'jwulf' })
@@ -102,7 +102,7 @@ describe('TasklistRESTClient', () => {
 
     it('will not allow a task to be claimed twice', async () => {
         const tasklist = new TasklistRESTClient()
-        const tasks = await tasklist.getTasks({ state: TaskState.CREATED })
+        const tasks = await tasklist.getTasks({ state: TaskStateREST.CREATED })
         const task = await tasklist.assignTask({ taskId: tasks[0].id, assignee: 'jwulf' })
         expect(task).toBeTruthy()
         let threw = false
@@ -116,7 +116,7 @@ describe('TasklistRESTClient', () => {
 
     it('can unclaim task', async () => {
         const tasklist = new TasklistRESTClient()
-        const tasks = await tasklist.getTasks({ state: TaskState.CREATED })
+        const tasks = await tasklist.getTasks({ state: TaskStateREST.CREATED })
         const taskId = tasks[0].id
         const task = await tasklist.assignTask({ taskId: taskId, assignee: 'jwulf' })
         expect(task).toBeTruthy()
@@ -134,7 +134,7 @@ describe('TasklistRESTClient', () => {
 
     it('can complete a Task', async () => {
         const tasklist = new TasklistRESTClient()
-        const tasks = await tasklist.getTasks({ state: TaskState.CREATED })
+        const tasks = await tasklist.getTasks({ state: TaskStateREST.CREATED })
         const taskid = tasks[0].id
         expect(tasks.length).toBeGreaterThan(0)
         const completeTask = await tasklist.completeTask(taskid, { outcome: 'approved', fruits: ['apple', 'orange'] })
@@ -157,7 +157,7 @@ describe('TasklistRESTClient', () => {
             done()
         })
         delay(10000)
-            .then(() => tasklist.getTasks({ state: TaskState.CREATED }))
+            .then(() => tasklist.getTasks({ state: TaskStateREST.CREATED }))
             .then((tasks) =>
                 tasks.forEach((task) =>
                     tasklist.completeTask(task.id, {

--- a/packages/tasklist-client-node-js/src/__test__/test.spec.ts
+++ b/packages/tasklist-client-node-js/src/__test__/test.spec.ts
@@ -18,9 +18,7 @@ describe('TasklistApiClient', () => {
     beforeAll(async () => {
         const bpmnFilePath = join(process.cwd(), 'src', '__test__', 'resources', 'TasklistTestProcess.bpmn')
         def = await zbc.deployProcess(bpmnFilePath)
-    })
 
-    beforeEach(async () => {
         p = await zbc.createProcessInstance({
             bpmnProcessId: 'TasklistTestProcess',
             variables: {
@@ -32,13 +30,12 @@ describe('TasklistApiClient', () => {
         await delay(10000) // we wait here to allow Tasklist to do its thing
     })
 
-    afterEach(async () => {
+    afterAll(async () => {
         if (p && p.processInstanceKey) {
             await zbc.cancelProcessInstance(p.processInstanceKey)
         }
+        zbc.close()
     })
-
-    afterAll(() => zbc.close())
 
     it('can request all tasks', async () => {
         const tasklist = new TasklistApiClient()

--- a/packages/tasklist-client-node-js/src/__test__/test.spec.ts
+++ b/packages/tasklist-client-node-js/src/__test__/test.spec.ts
@@ -15,10 +15,12 @@ describe('TasklistApiClient', () => {
         loglevel: 'NONE',
     })
 
-    beforeEach(async () => {
+    beforeAll(async () => {
         const bpmnFilePath = join(process.cwd(), 'src', '__test__', 'resources', 'TasklistTestProcess.bpmn')
         def = await zbc.deployProcess(bpmnFilePath)
+    })
 
+    beforeEach(async () => {
         p = await zbc.createProcessInstance({
             bpmnProcessId: 'TasklistTestProcess',
             variables: {

--- a/packages/tasklist-client-node-js/src/__test__/test.spec.ts
+++ b/packages/tasklist-client-node-js/src/__test__/test.spec.ts
@@ -15,7 +15,7 @@ describe('TasklistApiClient', () => {
         loglevel: 'NONE',
     })
 
-    beforeAll(async () => {
+    beforeEach(async () => {
         const bpmnFilePath = join(process.cwd(), 'src', '__test__', 'resources', 'TasklistTestProcess.bpmn')
         def = await zbc.deployProcess(bpmnFilePath)
 
@@ -30,12 +30,13 @@ describe('TasklistApiClient', () => {
         await delay(10000) // we wait here to allow Tasklist to do its thing
     })
 
-    afterAll(async () => {
+    afterEach(async () => {
         if (p && p.processInstanceKey) {
             await zbc.cancelProcessInstance(p.processInstanceKey)
         }
-        zbc.close()
     })
+
+    afterAll(() => zbc.close())
 
     it('can request all tasks', async () => {
         const tasklist = new TasklistApiClient()

--- a/packages/tasklist-client-node-js/src/lib/TasklistRESTClient.ts
+++ b/packages/tasklist-client-node-js/src/lib/TasklistRESTClient.ts
@@ -108,7 +108,7 @@ export class TasklistRESTClient {
      * @param formId
      * @param processDefinitionKey
      */
-    public async getForm(formId: string, processDefinitionKey: string): Promise<{ form: Form }> {
+    public async getForm(formId: string, processDefinitionKey: string): Promise<Form> {
         const headers = await this.getHeaders()
         return this.rest
             .get(`forms/${formId}`, {

--- a/packages/tasklist-client-node-js/src/lib/Types.ts
+++ b/packages/tasklist-client-node-js/src/lib/Types.ts
@@ -7,11 +7,7 @@ class TTaskState {
     CANCELED = literal`CANCELED`
 }
 
-export enum TaskStateREST {
-    COMPLETED = 'COMPLETED',
-    CREATED = 'CREATED',
-    CANCELED = 'CANCELED',
-}
+export type TaskStateREST = 'COMPLETED' | 'CREATED' | 'CANCELED'
 
 export const TaskState = new TTaskState()
 

--- a/packages/tasklist-client-node-js/src/lib/Types.ts
+++ b/packages/tasklist-client-node-js/src/lib/Types.ts
@@ -7,6 +7,12 @@ class TTaskState {
     CANCELED = literal`CANCELED`
 }
 
+export enum TaskStateREST {
+    COMPLETED = 'COMPLETED',
+    CREATED = 'CREATED',
+    CANCELED = 'CANCELED',
+}
+
 export const TaskState = new TTaskState()
 
 export interface Variable {
@@ -18,7 +24,7 @@ export interface Variable {
 }
 
 export interface TaskQuery {
-    state: LiteralObject
+    state: LiteralObject | TaskStateREST
     assigned: boolean
     assignee: string
     candidateGroup: string


### PR DESCRIPTION
~BLOCKED by #6 and #7. This PR targets the branch from #7, to avoid noise in the diff. Once 6 & 7 are merged, this should auto-adjust to targeting `main`.~

---

At least partially addresses https://github.com/camunda-community-hub/tasklist-client-node-js/issues/14.

* Gets existing Tasklist REST specs passing (or removes them in a couple cases).
* Updates the Tasklist types to accommodate a change that allows the REST specs to pass (described in-line).

## Not sure if....

There is [an important question in the in-line comments](https://github.com/camunda-community-hub/camunda-8-js-sdk/pull/8#discussion_r1421087530) about a decision I made. 

## Not included

* I initially thought I could refactor the tests to only spin up a process instance once per test suite, instead of once per test...but I ran into issues with this in the write operation tests and backed it out. I still think it's a valuable change given that right now each test takes at least 10 seconds to run. I got frustrated and couldn't make it work, but I might come back to this soon.

## What remains untested for the Tasklist REST client

I'm not sure how much of this we require for https://github.com/camunda-community-hub/tasklist-client-node-js/issues/14 to be considered complete, but here's what remains untested: 

- Ability to [include variables when searching for tasks](https://docs.camunda.io/docs/next/apis-tools/tasklist-api-rest/schemas/models/include-variable/) (as mentioned in https://github.com/camunda/developer-experience/issues/124#issuecomment-1834499146)
- Test ["save draft task variables" endpoint](https://docs.camunda.io/docs/apis-tools/tasklist-api-rest/controllers/tasklist-api-rest-task-controller/#save-draft-task-variables)
- Test ["search task variables" endpoint](https://docs.camunda.io/docs/apis-tools/tasklist-api-rest/controllers/tasklist-api-rest-task-controller/#search-task-variables)
- Test ["get variable" endpoint](https://docs.camunda.io/docs/apis-tools/tasklist-api-rest/controllers/tasklist-api-rest-variables-controller/#get-variable)